### PR TITLE
Fix Underline Text Draw Order

### DIFF
--- a/ECommons/ImGuiMethods/ImGuiEx.cs
+++ b/ECommons/ImGuiMethods/ImGuiEx.cs
@@ -55,10 +55,10 @@ public static class ImGuiEx
         var size = ImGui.CalcTextSize(text);
         var cur = ImGui.GetCursorScreenPos();
         cur.Y += size.Y;
-        ImGui.GetForegroundDrawList().PathLineTo(cur);
+        ImGui.GetWindowDrawList().PathLineTo(cur);
         cur.X += size.X;
-        ImGui.GetForegroundDrawList().PathLineTo(cur);
-        ImGui.GetForegroundDrawList().PathStroke(ImGuiColors.DalamudWhite.ToUint());
+        ImGui.GetWindowDrawList().PathLineTo(cur);
+        ImGui.GetWindowDrawList().PathStroke(ImGuiColors.DalamudWhite.ToUint());
         ImGuiEx.Text(text);
     }
 


### PR DESCRIPTION
`TextUnderlined` now uses the Window draw list as opposed to the foreground draw list. Fixes the issue when the ImGUI window isn't big enough to show the lines which resulted in lines just being drawn regardless of window size.