### PR TITLE
[FEATURE] Add CmdManager to easy init cmd.

### DIFF
--- a/ECommons/Commands/CmdAttribute.cs
+++ b/ECommons/Commands/CmdAttribute.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using ECommons.LanguageHelpers;
+using System;
 
 namespace ECommons.Commands;
 
@@ -20,7 +21,7 @@ public class CmdAttribute : Attribute
     public CmdAttribute(string command, string helpMessage = "", bool showInHelp = true, bool showInHelpPanel = true)
     {
         Command = command;
-        HelpMessage = helpMessage;
+        HelpMessage = helpMessage.Loc();
         ShowInHelp = showInHelp;
         ShowInHelpPanel = showInHelpPanel;
     }

--- a/ECommons/Commands/CmdAttribute.cs
+++ b/ECommons/Commands/CmdAttribute.cs
@@ -1,0 +1,27 @@
+﻿using System;
+
+namespace ECommons.Commands;
+
+[AttributeUsage(AttributeTargets.Method)]
+public class CmdAttribute : Attribute
+{
+    public string Command { get; }
+    public string HelpMessage { get; }
+    public bool ShowInHelp { get; }
+    public bool ShowInHelpPanel { get; }
+
+    /// <summary>
+    /// 
+    /// </summary>
+    /// <param name="command"></param>
+    /// <param name="helpMessage"></param>
+    /// <param name="showInHelp"></param>
+    /// <param name="showInHelpPanel">Whether show the major command help on the <seealso cref="ImGuiNET.ImGui"/> window</param>
+    public CmdAttribute(string command, string helpMessage = "", bool showInHelp = true, bool showInHelpPanel = true)
+    {
+        Command = command;
+        HelpMessage = helpMessage;
+        ShowInHelp = showInHelp;
+        ShowInHelpPanel = showInHelpPanel;
+    }
+}

--- a/ECommons/Commands/CmdManager.cs
+++ b/ECommons/Commands/CmdManager.cs
@@ -1,0 +1,123 @@
+﻿using ECommons.DalamudServices;
+using ImGuiNET;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+namespace ECommons.Commands;
+
+internal static class CmdManager
+{
+    static Dictionary<CmdAttribute, SubCmdAttribute[]> _commandsAttribute = new Dictionary<CmdAttribute, SubCmdAttribute[]>();
+
+    internal static void Init()
+    {
+        var plugin = ECommonsMain.Instance;
+        if (plugin == null) return;
+
+        foreach (var m in plugin.GetType().GetRuntimeMethods())
+        {
+            var types = m.GetParameters();
+            if (types.Length != 2
+                || types[0].ParameterType != typeof(string)
+                || types[1].ParameterType != typeof(string)) continue;
+
+            var cmdAttr = m.GetCustomAttribute<CmdAttribute>();
+            if (cmdAttr == null) continue;
+
+            Svc.Chat.Print("Find One!");
+
+            Svc.Commands.AddHandler(cmdAttr.Command, new Dalamud.Game.Command.CommandInfo((string command, string arguments) =>
+            {
+                m.Invoke(plugin, new object[] { command, arguments });
+            })
+            {
+                HelpMessage = cmdAttr.HelpMessage,
+                ShowInHelp = cmdAttr.ShowInHelp,
+            });
+
+            _commandsAttribute[cmdAttr] = m.GetCustomAttributes<SubCmdAttribute>().ToArray();
+        }
+    }
+
+    /// <summary>
+    /// Draw the help panel into the <seealso cref="ImGui"/> window.
+    /// </summary>
+    /// <param name="indent">The indent of value. 0 means no index, -1 means next line.</param>
+    public static void DrawHelp(float indent = 0)
+    {
+        bool isFirst = true;
+        foreach (var pair in _commandsAttribute)
+        {
+            if (isFirst) isFirst = false;
+            else ImGui.Spacing();
+
+            if (pair.Key.ShowInHelpPanel)
+            {
+                DisplayCommandHelp(pair.Key.Command, "", pair.Key.HelpMessage, indent);
+            }
+            foreach (var sub in pair.Value)
+            {
+                if (sub == null) continue;
+                DisplayCommandHelp(pair.Key.Command, sub.SubCommand, sub.HelpMessage, indent);
+            }
+        }
+    }
+
+    private static void DisplayCommandHelp(string command, string extraCommand = "", string helpMessage = "", float indent = 0)
+    {
+        if (string.IsNullOrEmpty(command)) return;
+        if (!string.IsNullOrEmpty(extraCommand))
+        {
+            command += " " + extraCommand;
+        }
+
+        if (ImGui.Button(command))
+        {
+            Svc.Commands.ProcessCommand(command);
+        }
+        if (ImGui.IsItemHovered())
+        {
+            ImGui.SetTooltip($"Click to execute the command: {command}\nRight-click to copy the command: {command}");
+
+            if (ImGui.IsMouseClicked(ImGuiMouseButton.Right))
+            {
+                ImGui.SetClipboardText(command);
+            }
+        }
+
+        if (!string.IsNullOrEmpty(helpMessage))
+        {
+            if (indent > 0)
+            {
+                ImGui.SameLine();
+                ImGui.Indent(indent);
+            }
+            else
+            {
+                if (indent < 0)
+                {
+                    ImGui.Text("    ");
+                }
+                ImGui.SameLine();
+            }
+
+            ImGui.Text(" → ");
+            ImGui.SameLine();
+            ImGui.TextWrapped(helpMessage);
+
+            if (indent > 0)
+            {
+                ImGui.Unindent(indent);
+            }
+        }
+    }
+
+    internal static void Dispose()
+    {
+        foreach (var cmd in _commandsAttribute.Keys)
+        {
+            Svc.Commands.RemoveHandler(cmd.Command);
+        }
+    }
+}

--- a/ECommons/Commands/CmdManager.cs
+++ b/ECommons/Commands/CmdManager.cs
@@ -1,4 +1,5 @@
 ﻿using ECommons.DalamudServices;
+using ECommons.LanguageHelpers;
 using ImGuiNET;
 using System.Collections.Generic;
 using System.Linq;
@@ -64,7 +65,7 @@ internal static class CmdManager
         }
     }
 
-    private static void DisplayCommandHelp(string command, string extraCommand = "", string helpMessage = "", float indent = 0)
+    public static void DisplayCommandHelp(string command, string extraCommand = "", string helpMessage = "", float indent = 0)
     {
         if (string.IsNullOrEmpty(command)) return;
         if (!string.IsNullOrEmpty(extraCommand))

--- a/ECommons/Commands/SubCmdAttribute.cs
+++ b/ECommons/Commands/SubCmdAttribute.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using ECommons.LanguageHelpers;
+using System;
 
 namespace ECommons.Commands;
 
@@ -10,7 +11,7 @@ public class SubCmdAttribute : Attribute
 
     public SubCmdAttribute(string subCommand, string helpMessage = "")
     {
-        this.SubCommand = subCommand;
-        this.HelpMessage = helpMessage;
+        SubCommand = subCommand;
+        HelpMessage = helpMessage.Loc();
     }
 }

--- a/ECommons/Commands/SubCmdAttribute.cs
+++ b/ECommons/Commands/SubCmdAttribute.cs
@@ -1,0 +1,16 @@
+﻿using System;
+
+namespace ECommons.Commands;
+
+[AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
+public class SubCmdAttribute : Attribute
+{
+    public string SubCommand { get; }
+    public string HelpMessage { get; }
+
+    public SubCmdAttribute(string subCommand, string helpMessage = "")
+    {
+        this.SubCommand = subCommand;
+        this.HelpMessage = helpMessage;
+    }
+}

--- a/ECommons/ECommonsMain.cs
+++ b/ECommons/ECommonsMain.cs
@@ -14,6 +14,7 @@ using ECommons.Loader;
 using ECommons.Automation;
 using ECommons.StringHelpers;
 using Dalamud.Utility;
+using ECommons.Commands;
 
 namespace ECommons;
 
@@ -26,6 +27,7 @@ public static class ECommonsMain
     {
         Instance = instance;
         GenericHelpers.Safe(() => Svc.Init(pluginInterface));
+        GenericHelpers.Safe(CmdManager.Init);
         if (modules.ContainsAny(Module.All, Module.ObjectFunctions))
         {
             PluginLog.Information("Object functions module has been requested");
@@ -52,6 +54,7 @@ public static class ECommonsMain
     {
         Disposed = true;
         GenericHelpers.Safe(PluginLoader.Dispose);
+        GenericHelpers.Safe(CmdManager.Dispose);
         if (EzConfig.Config != null)
         {
             GenericHelpers.Safe(EzConfig.Save);

--- a/ECommons/EzCmd.cs
+++ b/ECommons/EzCmd.cs
@@ -1,6 +1,7 @@
 ﻿using Dalamud.Game.Command;
 using ECommons.DalamudServices;
 using ECommons.Reflection;
+using System;
 using System.Collections.Generic;
 using static Dalamud.Game.Command.CommandInfo;
 
@@ -10,6 +11,7 @@ public static class EzCmd
 {
     internal static List<string> RegisteredCommands = new();
 
+    [Obsolete("Please use Cmd Attribute to the method in IDalamudPlugin to Add your command.")]
     public static void Add(string command, HandlerDelegate action, string helpMessage = null)
     {
         RegisteredCommands.Add(command);


### PR DESCRIPTION
This is an easy way to init cmd. and create a friendly cmd help panel in IMGUI.

For example, write the code in your `IDalamudPlugin` file like this. It'll automatically add a handle of your command of it and dispose of course.

``` C#
    [Cmd("/fulf", "En/Disable FULF with /fulf or change the loot rule with /fulf need | greed or pass .")]
    [SubCmd("need", "Set need for FULF")]
    [SubCmd("greed", "Set greed for FULF")]
    [SubCmd("pass", "Set pass for FULF")]
    void FulfCommand(string command, string arguments)
    {
    }


    [Cmd("/rolling", "Roll for the loot according to the argument and the item's RollResult. /rolling need | greed | pass or passall", showInHelpPanel: false)]
    [SubCmd("need", "Rolling need")]
    [SubCmd("greed", "Rolling greed")]
    [SubCmd("pass", "Rolling pass")]
    void RollingCommand(string command, string arguments)
    {
    }

    [Cmd("/lazy", "Open Lazy Loot config.")]
    void OpenConfigCommand(string command, string arguments)
    {
    }
```

If you write the code like this in `IMGUI` drawing method, you'll see something like this.
``` C#
CmdManager.DrawHelp(100);
```
![image](https://github.com/NightmareXIV/ECommons/assets/53346444/381407a3-bc82-48aa-b235-57a064b43cc4)

NOTICE: This feature used the imgui method, however, I didn't move it to IMGUI folder. If you want to do this, please check it.
