### PR TITLE
FIX! : ActionEffectType change.

### DIFF
--- a/ECommons/Hooks/ActionEffectTypes/ActionEffectSet.cs
+++ b/ECommons/Hooks/ActionEffectTypes/ActionEffectSet.cs
@@ -38,20 +38,21 @@ public unsafe struct ActionEffectSet
         switch (effectHeader->ActionType)
         {
             case ActionType.Item:
-                Item = Svc.Data.GetExcelSheet<Item>().GetRow(effectHeader->ActionID);
-                Name = Item?.Name;
+                var id = effectHeader->ActionID > 1000000 ? effectHeader->ActionID - 1000000 : effectHeader->ActionID;
+                Item = Svc.Data.GetExcelSheet<Item>().GetRow(id);
+                Name = Item?.Name ?? string.Empty;
                 IconId = Item?.Icon ?? 0;
                 break;
 
             case ActionType.Mount:
                 Mount = Svc.Data.GetExcelSheet<Mount>().GetRow(effectHeader->ActionID);
-                Name = Mount?.Singular;
+                Name = Mount?.Singular ?? string.Empty;
                 IconId = Mount?.Icon ?? 0;
                 break;
 
             default:
                 Action = Svc.Data.GetExcelSheet<Action>().GetRow(effectHeader->ActionID);
-                Name = Action?.Name;
+                Name = Action?.Name ?? string.Empty; ;
 
                 var actionCate = Action?.ActionCategory.Value?.RowId ?? 0;
 

--- a/ECommons/Hooks/ActionEffectTypes/ActionEffectType.cs
+++ b/ECommons/Hooks/ActionEffectTypes/ActionEffectType.cs
@@ -20,7 +20,11 @@ public enum ActionEffectType : byte
     MpGain = 11,
     TpLoss = 12,
     TpGain = 13,
+
+    [Obsolete("Please use ApplyStatusEffectTarget instead.")]
+    GpGain = ApplyStatusEffectTarget,
     ApplyStatusEffectTarget = 14,
+
     ApplyStatusEffectSource = 15,
     RecoveredFromStatusEffect = 16,
     LoseStatusEffectTarget = 17,
@@ -37,6 +41,7 @@ public enum ActionEffectType : byte
     [Obsolete("Please use ComboSucceed instead.")]
     Unknown1 = ComboSucceed,
     ComboSucceed = 28,
+
     Retaliation = 29,
     Knockback = 32,
     Attract1 = 33, //Here is an issue bout knockback. some is 32 some is 33.

--- a/ECommons/Hooks/ActionEffectTypes/ActionEffectType.cs
+++ b/ECommons/Hooks/ActionEffectTypes/ActionEffectType.cs
@@ -20,9 +20,9 @@ public enum ActionEffectType : byte
     MpGain = 11,
     TpLoss = 12,
     TpGain = 13,
-    GpGain = 14,
-    ApplyStatusEffectTarget = 15,
-    ApplyStatusEffectSource = 16,
+    ApplyStatusEffectTarget = 14,
+    ApplyStatusEffectSource = 15,
+    RecoveredFromStatusEffect = 16,
     LoseStatusEffectTarget = 17,
     LoseStatusEffectSource = 18,
     StatusNoEffect = 20,
@@ -33,9 +33,14 @@ public enum ActionEffectType : byte
     [Obsolete("Please use StartActionCombo instead.")]
     Unknown0 = StartActionCombo,
     StartActionCombo = 27,
-    Unknown1 = 28,
+
+    [Obsolete("Please use ComboSucceed instead.")]
+    Unknown1 = ComboSucceed,
+    ComboSucceed = 28,
     Retaliation = 29,
     Knockback = 32,
+    Attract1 = 33, //Here is an issue bout knockback. some is 32 some is 33.
+    Attract2 = 34,
     Mount = 40,
     FullResistStatus = 52,
     VFX = 59,


### PR DESCRIPTION
After many tests, I found that 14-16 was wrong. And I checked the code about `ActionEffectType` on github. Here are some links.

- [awgil](https://github.com/awgil/ffxiv_reverse/blame/eb09b0b01deea1813ebeb9a004c852dd5c6e098b/vnetlog/vnetlog/ServerIPC.cs#L498-L553)
- [Athavar](https://github.com/Athavar/Athavar.FFXIV.Plugin/blame/a785e67a7ab9b3df6146503f8927f8dd56090252/src/Athavar.FFXIV.Plugin.Dps/Data/ActionEffect/ActionEffectType.cs#L7-L62)
- [Kouzukii](https://github.com/Kouzukii/ffxiv-deathrecap/blame/fc2fee682945e5b28544548b49b137448fb28993/Game/ActionEffectType.cs#L3-L34)
- [0ceal0t](https://github.com/0ceal0t/JobBars/blame/1bf1447f82de871dda74398cb550bcd86d5f5a8e/JobBars/GameStructs/ActionEffectStructs.cs#L2-L26)
- [Bluefissure](https://github.com/Bluefissure/MultiHit/blame/de7be2891113591669a8afac674676aa359384ab/MultiHit/Enums.cs#L3-L29)
- [Bedo9041](https://github.com/Bedo9041/DamageInfoPlugin/blame/dcaa9121c05d7c33f41cad7ef4c80ea41d9f44ab/DamageInfoPlugin/DamageInfoEnums.cs#L3-L28)

It is easy to see that 14-16 has changed recently.

This may change a lot! Please notice that!
