### PR TITLE
Add generic IndexOf extension method for IEnumerable

### DIFF
--- a/ECommons/GenericHelpers.cs
+++ b/ECommons/GenericHelpers.cs
@@ -39,6 +39,20 @@ namespace ECommons;
 
 public static unsafe class GenericHelpers
 {
+    public static int IndexOf<T>(this IEnumerable<T> values, Predicate<T> predicate)
+    {
+        var ret = -1;
+        foreach(var v in values)
+        {
+            ret++;
+            if(predicate(v))
+            {
+                return ret;
+            }
+        }
+        return -1;
+    }
+    
     public static bool ContainsIgnoreCase(this IEnumerable<string> haystack, string needle)
     {
         foreach(var x in haystack)


### PR DESCRIPTION
Implemented a generic extension method 'IndexOf' for IEnumerable<T> that allows finding the index of the first element matching a given predicate. This method enhances collection handling by providing a flexible way to search for elements based on custom conditions.