### PR TITLE
Adds Variant of TextInputMultilineExpanding that has Automatic Text Wrap.

### DIFF
--- a/ECommons/ImGuiMethods/ImGuiEx/ImGuiEx.cs
+++ b/ECommons/ImGuiMethods/ImGuiEx/ImGuiEx.cs
@@ -417,6 +417,80 @@ public static unsafe partial class ImGuiEx
         ImGui.SetNextItemWidth(width.Scale());
     }
 
+    private static int FindWrapPosition(string text, float wrapWidth)
+    {
+         float currentWidth = 0;
+         int lastSpacePos = -1;
+         for (int i = 0; i < text.Length; i++)
+         {
+              char c = text[i];
+              currentWidth += ImGui.CalcTextSize(c.ToString()).X;
+              if (char.IsWhiteSpace(c))
+              {
+                   lastSpacePos = i;
+              }
+              if (currentWidth > wrapWidth)
+              {
+                   return lastSpacePos >= 0 ? lastSpacePos : i;
+              }
+         }
+         return -1;
+    }
+
+    private static unsafe int TextEditCallback(ImGuiInputTextCallbackData* data, float wrapWidth)
+    {
+        string text = Marshal.PtrToStringAnsi((IntPtr)data->Buf, data->BufTextLen);
+        var lines = text.Split('\n').ToList();
+        bool textModified = false;
+        // Traverse each line to check if it exceeds the wrap width
+        for (int i = 0; i < lines.Count; i++)
+        {
+            float lineWidth = ImGui.CalcTextSize(lines[i]).X;
+            while (lineWidth + 10f > wrapWidth)
+            {
+                // Find where to break the line
+                int wrapPos = FindWrapPosition(lines[i], wrapWidth);
+                if (wrapPos >= 0)
+                {
+                    // Insert a newline at the wrap position
+                    string part1 = lines[i].Substring(0, wrapPos);
+                    string part2 = lines[i].Substring(wrapPos).TrimStart();
+                    lines[i] = part1;
+                    lines.Insert(i + 1, part2);
+                    textModified = true;
+                    lineWidth = ImGui.CalcTextSize(part2).X;
+                }
+                else
+                {
+                    break;
+                }
+            }
+        }
+        // Merge all lines back to the buffer
+        if (textModified)
+        {
+            string newText = string.Join("\n", lines);
+            byte[] newTextBytes = Encoding.UTF8.GetBytes(newText.PadRight(data->BufSize, '\0'));
+            Marshal.Copy(newTextBytes, 0, (IntPtr)data->Buf, newTextBytes.Length);
+            data->BufTextLen = newText.Length;
+            data->BufDirty = 1;
+            data->CursorPos = Math.Min(data->CursorPos, data->BufTextLen);
+        }
+        return 0;
+    }
+     
+    public unsafe static bool InputTextWrapMultilineExpanding(string id, ref string text, uint maxLength = 500, int minLines = 2, int maxLines = 10, int? width = null)
+    {
+        float wrapWidth = width ?? ImGui.GetContentRegionAvail().X; // determine wrap width
+        bool result = ImGui.InputTextMultiline(id, ref text, maxLength,
+            new(width ?? ImGui.GetContentRegionAvail().X, ImGui.CalcTextSize("A").Y * Math.Clamp(text.Split("\n").Length + 1, minLines, maxLines)),
+            ImGuiInputTextFlags.CallbackEdit, // flag stuff 
+            (data) => {
+                return TextEditCallback(data, wrapWidth); // Callback Action
+            });
+        return result;
+    }
+
     public static bool InputTextMultilineExpanding(string id, ref string text, uint maxLength = 500, int minLines = 2, int maxLines = 10, int? width = null)
     {
         return ImGui.InputTextMultiline(id, ref text, maxLength, new(width ?? ImGui.GetContentRegionAvail().X, ImGui.CalcTextSize("A").Y * Math.Clamp(text.Split("\n").Length + 1, minLines, maxLines)));


### PR DESCRIPTION
Pulled together from a variation of several individual user attempts over the years who tried to create this method into one, optimized, clean approach that works consistently and is not costly on performance much at all.

Auto-wraps text once you reach the end of the text box into the next row, auto-removes leading spaces on the left padding from enters, and also monitors each line so editing text earlier in your message will still keep it within the box.