### PR TITLE
Add FriendlyBattleNPC to NameplateKind enum

### DIFF
--- a/ECommons/GameFunctions/NameplateKind.cs
+++ b/ECommons/GameFunctions/NameplateKind.cs
@@ -12,4 +12,5 @@ public enum NameplateKind
     HostileEngagedSelfUndamaged = 9,
     HostileEngagedOther = 10,
     HostileEngagedSelfDamaged = 11,
+    FriendlyBattleNPC = 12,
 }


### PR DESCRIPTION
Added a new enum member `FriendlyBattleNPC` with a value of `12` to the `NameplateKind` enum in the `NameplateKind.cs` file. This new value represents a friendly non-player combat character, typically found in solo instances where they are not in your party.