### PR TITLE
add window toggle function and window name override

### DIFF
--- a/ECommons/SimpleGui/ConfigWindow.cs
+++ b/ECommons/SimpleGui/ConfigWindow.cs
@@ -1,15 +1,15 @@
 ﻿using Dalamud.Interface.Windowing;
 using ECommons.Configuration;
 using ECommons.DalamudServices;
-using ECommons.ImGuiMethods;
 using ECommons.Logging;
 using ECommons.Reflection;
 
 namespace ECommons.SimpleGui;
+#nullable disable
 
 public class ConfigWindow : Window
 {
-    public ConfigWindow() : base($"{DalamudReflector.GetPluginName()} v{ECommonsMain.Instance.GetType().Assembly.GetName().Version}###{DalamudReflector.GetPluginName()}")
+    public ConfigWindow(string name = null) : base($"{name ?? $"{DalamudReflector.GetPluginName()} v{ECommonsMain.Instance.GetType().Assembly.GetName().Version}"}###{DalamudReflector.GetPluginName()}")
     {
         SizeConstraints = new()
         {

--- a/ECommons/SimpleGui/EzConfigGui.cs
+++ b/ECommons/SimpleGui/EzConfigGui.cs
@@ -18,10 +18,10 @@ public static class EzConfigGui
     private static ConfigWindow configWindow;
     public static Window Window { get { return configWindow; } }
 
-    public static void Init(Action draw, IPluginConfiguration config = null)
+    public static void Init(Action draw, IPluginConfiguration config = null, string nameOverride = null)
     {
         Draw = draw;
-        Init(config);
+        Init(config, nameOverride);
     }
 
     public static T Init<T>(T window, IPluginConfiguration config = null) where T : ConfigWindow
@@ -31,7 +31,7 @@ public static class EzConfigGui
         return window;
     }
 
-    private static void Init(IPluginConfiguration config)
+    private static void Init(IPluginConfiguration config, string nameOverride = null)
     {
         if(WindowSystem != null)
         {
@@ -39,7 +39,7 @@ public static class EzConfigGui
         }
         WindowSystem = new($"ECommons@{DalamudReflector.GetPluginName()}");
         Config = config;
-        configWindow ??= new();
+        configWindow ??= new(nameOverride);
         WindowSystem.AddWindow(configWindow);
         Svc.PluginInterface.UiBuilder.Draw += WindowSystem.Draw;
         Svc.PluginInterface.UiBuilder.OpenConfigUi += Open;
@@ -54,6 +54,8 @@ public static class EzConfigGui
     {
         Open();
     }
+
+    public static void Toggle() => configWindow.Toggle();
 
     /// <summary>
     /// Returns a window from the EzGui WindowSystem.


### PR DESCRIPTION
since window name fetches your internalname, if you change the plugin name then your main window will never be able to update accordingly without changing that too (which is infeasible)