### PR TITLE
Fix possibility of null reference and dispose errors

### DIFF
--- a/ECommons/Configuration/ExternalWriter.cs
+++ b/ECommons/Configuration/ExternalWriter.cs
@@ -21,14 +21,20 @@ public static class ExternalWriter
 
     public static void PlaceWriteOrder(FileSaveStruct order)
     {
-        if(!FileSaveRequests.TryAdd(order))
+        if (FileSaveRequests == null)
+        {
+            PluginLog.Warning($"[FileWriterServer] FileSaveRequests is null, cannot place write order.");
+            return;
+        }
+
+        if (!FileSaveRequests.TryAdd(order))
         {
             PluginLog.Warning($"[FileWriterServer] PlaceWriteOrder failed, trying on another tick");
             Svc.Framework.RunOnTick(() => PlaceWriteOrder(order));
         }
         else
         {
-            if(!ThreadIsRunning)
+            if (!ThreadIsRunning)
             {
                 ThreadIsRunning = true;
                 BeginThread();

--- a/ECommons/Hooks/ActionEffect.cs
+++ b/ECommons/Hooks/ActionEffect.cs
@@ -78,16 +78,22 @@ public static unsafe class ActionEffect
 
     public static void Disable()
     {
-        if(ProcessActionEffectHook?.IsEnabled == true) ProcessActionEffectHook?.Disable();
+        if (ProcessActionEffectHook != null && !ProcessActionEffectHook.IsDisposed && ProcessActionEffectHook.IsEnabled)
+        {
+            ProcessActionEffectHook.Disable();
+        }
     }
 
     internal static void Dispose()
     {
-        if(ProcessActionEffectHook != null)
+        if (ProcessActionEffectHook != null)
         {
             PluginLog.Information($"Disposing Action Effect Hook");
             Disable();
-            ProcessActionEffectHook?.Dispose();
+            if (!ProcessActionEffectHook.IsDisposed)
+            {
+                ProcessActionEffectHook.Dispose();
+            }
             ProcessActionEffectHook = null;
         }
     }


### PR DESCRIPTION
Fix possibility of null reference and dispose errors

Fix for CS8602 warning:

* [`ECommons/Configuration/ExternalWriter.cs`](diffhunk://#diff-4c02dfc14e56ab63c70c094f90a439be788042032659a40d1af6c343a53082bdR24-R29): Added a null check for `FileSaveRequests` in the `PlaceWriteOrder` method to prevent null reference exceptions and log a warning if it is null.

Fix dispose errors in Dalamud:

* [`ECommons/Hooks/ActionEffect.cs`](diffhunk://#diff-49964172d97da76daa74cdf0217476830ad59ec2082090e8e77dcfe818e9b19cL81-R84): Modified the `Enable` method to include additional checks for `ProcessActionEffectHook` being non-null, not disposed, and enabled before calling `Disable`.
* [`ECommons/Hooks/ActionEffect.cs`](diffhunk://#diff-49964172d97da76daa74cdf0217476830ad59ec2082090e8e77dcfe818e9b19cL90-R96): Updated the `Dispose` method to ensure `ProcessActionEffectHook` is not disposed before calling `Dispose` on it and set `ProcessActionEffectHook` to null afterward.