### PR TITLE
Add System.Text namespace to DefaultSerializationFactory to fix build failure

### DIFF
--- a/ECommons/Configuration/DefaultSerializationFactory.cs
+++ b/ECommons/Configuration/DefaultSerializationFactory.cs
@@ -2,6 +2,7 @@
 using ECommons.Reflection;
 using Newtonsoft.Json;
 using System.Reflection;
+using System.Text;
 
 namespace ECommons.Configuration;
 /// <summary>


### PR DESCRIPTION
A new `using System.Text;` directive was added to the `DefaultSerializationFactory.cs` file to fix build failure due to "Encoding" on line 43 and 79.