### PR TITLE
Add `Spacing(Vector2, bool)` to support vertical spacing, correct some Scaling

### DIFF
--- a/ECommons/ImGuiMethods/ImGuiEx/ImGuiEx.cs
+++ b/ECommons/ImGuiMethods/ImGuiEx/ImGuiEx.cs
@@ -1236,9 +1236,21 @@ public static unsafe partial class ImGuiEx
         return ImGui.GetWindowContentRegionMax().X - ImGui.GetWindowContentRegionMin().X;
     }
 
+    [Obsolete("Use ImGuiEx.Spacing(Vector2, bool) instead")]
     public static void Spacing(float pix = 10f, bool accountForScale = true)
     {
         ImGui.SetCursorPosX(ImGui.GetCursorPosX() + (accountForScale ? pix : pix * ImGuiHelpers.GlobalScale));
+    }
+
+    public static void Spacing(Vector2? size = null, bool accountForScale = true)
+    {
+        size ??= new Vector2(10f);
+
+        var x = size.Value.X * (accountForScale ? ImGuiHelpers.GlobalScale : 1f);
+        var y = size.Value.Y * (accountForScale ? ImGuiHelpers.GlobalScale : 1f);
+
+        ImGui.SetCursorPosX(ImGui.GetCursorPosX() + x);
+        ImGui.SetCursorPosY(ImGui.GetCursorPosY() + y);
     }
 
     public static float Scale(this float f)

--- a/ECommons/ImGuiMethods/ImGuiEx/ImGuiEx.cs
+++ b/ECommons/ImGuiMethods/ImGuiEx/ImGuiEx.cs
@@ -53,6 +53,12 @@ public static unsafe partial class ImGuiEx
         return f * ImGuiHelpers.GlobalScale * (Svc.PluginInterface.UiBuilder.DefaultFontSpec.SizePt / 12f);
     }
 
+    /// <seealso cref="Scale(float)"/>
+    public static float? Scale(this float? f)
+    {
+        return f?.Scale();
+    }
+
     public static bool BeginDefaultTable(string[] headers, bool drawHeader = true)
     {
         return BeginDefaultTable("##ECommonsDefaultTable", headers, drawHeader);

--- a/ECommons/ImGuiMethods/ImGuiEx/ImGuiEx.cs
+++ b/ECommons/ImGuiMethods/ImGuiEx/ImGuiEx.cs
@@ -30,6 +30,29 @@ public static unsafe partial class ImGuiEx
     public static readonly ImGuiTableFlags DefaultTableFlags = ImGuiTableFlags.NoSavedSettings | ImGuiTableFlags.RowBg | ImGuiTableFlags.Borders | ImGuiTableFlags.SizingFixedFit;
     private static Dictionary<string, int> SelectedPages = [];
 
+    /// <seealso cref="Scale(float)"/>
+    public static Vector2? Scale(this Vector2? v)
+    {
+        if(v == null) return null;
+        return new Vector2(v.Value.X.Scale(), v.Value.Y.Scale());
+    }
+
+    /// <seealso cref="Scale(float)"/>
+    public static Vector2 Scale(this Vector2 v)
+    {
+        return new Vector2(v.X.Scale(), v.Y.Scale());
+    }
+
+    /// <summary>
+    ///     Scale a float value based on the two independent Dalamud UI scaling factors.
+    /// </summary>
+    /// <param name="f">The float value to scale.</param>
+    /// <returns>The float value scaled with the user's style settings.</returns>
+    public static float Scale(this float f)
+    {
+        return f * ImGuiHelpers.GlobalScale * (Svc.PluginInterface.UiBuilder.DefaultFontSpec.SizePt / 12f);
+    }
+
     public static bool BeginDefaultTable(string[] headers, bool drawHeader = true)
     {
         return BeginDefaultTable("##ECommonsDefaultTable", headers, drawHeader);
@@ -267,6 +290,7 @@ public static unsafe partial class ImGuiEx
     }
 
     public static void TreeNodeCollapsingHeader(string name, Action action, ImGuiTreeNodeFlags extraFlags = ImGuiTreeNodeFlags.None) => TreeNodeCollapsingHeader(name, true, action, extraFlags);
+
     /// <summary>
     /// Another interpretation of <see cref="ImGui.CollapsingHeader(string)"/> but with narrow design and border.
     /// </summary>
@@ -435,7 +459,6 @@ public static unsafe partial class ImGuiEx
     /// <inheritdoc cref="SelectableNode(Vector4?, string, bool)"/>
     public static bool SelectableNode(string id, ref bool selected, bool enabled = true) => SelectableNode(null, id, ref selected, enabled:enabled);
 
-
     /// <summary>
     /// Selectable item made from TreeNode
     /// </summary>
@@ -529,7 +552,7 @@ public static unsafe partial class ImGuiEx
                 {
                     if(ThreadLoadImageHandler.TryGetIconTextureWrap((uint)cond.GetIcon(), false, out var texture))
                     {
-                        ImGui.Image(texture.ImGuiHandle, new Vector2(24f));
+                        ImGui.Image(texture.ImGuiHandle, new Vector2(24f.Scale()));
                         ImGui.SameLine();
                     }
                     if(ImGuiEx.CollectionCheckbox(name, cond, selectedJobs)) ret = true;
@@ -1090,6 +1113,8 @@ public static unsafe partial class ImGuiEx
         return ret;
     }
 
+    public static bool ButtonCtrlScaled(string text, Vector2? size, string affix = " (Hold CTRL)") => ButtonCtrl(text, size.Scale(), affix);
+
     public static bool BeginPopupNextToElement(string popupId)
     {
         ImGui.SameLine(0, 0);
@@ -1118,7 +1143,6 @@ public static unsafe partial class ImGuiEx
     {
         if(ImGui.IsWindowCollapsed()) return false;
 
-        var scale = ImGuiHelpers.GlobalScale;
         var currentID = ImGui.GetID(0);
         if(currentID != headerLastWindowID || headerLastFrame != Svc.PluginInterface.UiBuilder.FrameCount)
         {
@@ -1129,15 +1153,15 @@ public static unsafe partial class ImGuiEx
                 headerCurrentPos = 1;
             headerImGuiButtonWidth = 0f;
             if(CurrentWindowHasCloseButton())
-                headerImGuiButtonWidth += 17 * scale;
+                headerImGuiButtonWidth += 17f.Scale();
             if(!GetCurrentWindowFlags().HasFlag(ImGuiWindowFlags.NoCollapse))
-                headerImGuiButtonWidth += 17 * scale;
+                headerImGuiButtonWidth += 17f.Scale();
         }
 
         options ??= new();
         var prevCursorPos = ImGui.GetCursorPos();
-        var buttonSize = new Vector2(20 * scale);
-        var buttonPos = new Vector2((ImGui.GetWindowWidth() - buttonSize.X - headerImGuiButtonWidth * scale * headerCurrentPos) - (ImGui.GetStyle().FramePadding.X * scale), ImGui.GetScrollY() + 1);
+        var buttonSize = new Vector2(20f.Scale());
+        var buttonPos = new Vector2((ImGui.GetWindowWidth() - buttonSize.X - headerImGuiButtonWidth.Scale() * headerCurrentPos) - (ImGui.GetStyle().FramePadding.X.Scale()), ImGui.GetScrollY() + 1);
         ImGui.SetCursorPos(buttonPos);
         var drawList = ImGui.GetWindowDrawList();
         drawList.PushClipRectFullScreen();
@@ -1239,24 +1263,18 @@ public static unsafe partial class ImGuiEx
     [Obsolete("Use ImGuiEx.Spacing(Vector2, bool) instead")]
     public static void Spacing(float pix = 10f, bool accountForScale = true)
     {
-        ImGui.SetCursorPosX(ImGui.GetCursorPosX() + (accountForScale ? pix : pix * ImGuiHelpers.GlobalScale));
+        ImGui.SetCursorPosX(ImGui.GetCursorPosX() + (accountForScale ? pix : pix.Scale()));
     }
 
     public static void Spacing(Vector2? size = null, bool accountForScale = true)
     {
         size ??= new Vector2(10f);
 
-        var x = size.Value.X * (accountForScale ? ImGuiHelpers.GlobalScale : 1f);
-        var y = size.Value.Y * (accountForScale ? ImGuiHelpers.GlobalScale : 1f);
+        if (accountForScale)
+            size = size.Scale();
 
-        ImGui.SetCursorPosX(ImGui.GetCursorPosX() + x);
-        ImGui.SetCursorPosY(ImGui.GetCursorPosY() + y);
-    }
-
-    public static float Scale(this float f)
-    {
-        // Dalamud global scale and font size are now indepedent from each other, so both need to factored in.
-        return f * ImGuiHelpers.GlobalScale * (Svc.PluginInterface.UiBuilder.DefaultFontSpec.SizePt / 12f);
+        ImGui.SetCursorPosX(ImGui.GetCursorPosX() + size!.Value.X);
+        ImGui.SetCursorPosY(ImGui.GetCursorPosY() + size!.Value.Y);
     }
 
     public static void SetTooltip(string text)
@@ -1707,6 +1725,20 @@ public static unsafe partial class ImGuiEx
         return IconButton(icon.ToIconString(), id, size, enabled);
     }
 
+    public static bool IconButtonScaled(FontAwesomeIcon icon, string id = "ECommonsButton", Vector2 size = default, bool enabled = true) => IconButton(icon, id, size.Scale(), enabled);
+
+    public static bool IconButton(string icon, string id = "ECommonsButton", Vector2 size = default, bool enabled = true)
+    {
+        ImGui.PushFont(UiBuilder.IconFont);
+        if(!enabled) ImGui.PushStyleVar(ImGuiStyleVar.Alpha, ImGui.GetStyle().Alpha * 0.6f);
+        var result = ImGui.Button($"{icon}##{icon}-{id}", size) && enabled;
+        if(!enabled) ImGui.PopStyleVar();
+        ImGui.PopFont();
+        return result;
+    }
+
+    public static bool IconButtonScaled(string icon, string id = "ECommonsButton", Vector2 size = default, bool enabled = true) => IconButton(icon, id, size.Scale(), enabled);
+
     public static bool SmallButton(string label, bool enabled = true)
     {
         if(!enabled) ImGui.PushStyleVar(ImGuiStyleVar.Alpha, ImGui.GetStyle().Alpha * 0.6f);
@@ -1731,15 +1763,7 @@ public static unsafe partial class ImGuiEx
         return ret;
     }
 
-    public static bool IconButton(string icon, string id = "ECommonsButton", Vector2 size = default, bool enabled = true)
-    {
-        ImGui.PushFont(UiBuilder.IconFont);
-        if(!enabled) ImGui.PushStyleVar(ImGuiStyleVar.Alpha, ImGui.GetStyle().Alpha * 0.6f);
-        var result = ImGui.Button($"{icon}##{icon}-{id}", size) && enabled;
-        if(!enabled) ImGui.PopStyleVar();
-        ImGui.PopFont();
-        return result;
-    }
+    public static bool ButtonScaled(string label, Vector2 size, bool enabled = true) => Button(label, size.Scale(), enabled);
 
     public static bool IconButtonWithText(FontAwesomeIcon icon, string id, bool enabled = true)
     {
@@ -1749,17 +1773,17 @@ public static unsafe partial class ImGuiEx
         return result;
     }
 
-    public static Vector2 CalcIconSize(FontAwesomeIcon icon, bool isButton = false)
-    {
-        return CalcIconSize(icon.ToIconString(), isButton);
-    }
-
     public static Vector2 CalcIconSize(string icon, bool isButton = false)
     {
         ImGui.PushFont(UiBuilder.IconFont);
         var result = ImGui.CalcTextSize($"{icon}");
         ImGui.PopFont();
         return result + (isButton ? ImGui.GetStyle().FramePadding * 2f : Vector2.Zero);
+    }
+
+    public static Vector2 CalcIconSize(FontAwesomeIcon icon, bool isButton = false)
+    {
+        return CalcIconSize(icon.ToIconString(), isButton);
     }
 
     public static float Measure(Action func, bool includeSpacing = true)


### PR DESCRIPTION
This replaces the old `Spacing(float, bool)` method with a new (overload) `Spacing(Vector2, bool)` method, in order to support Y-axis spacing, and brings it more inline with `ImGui.Dummy()` which it effectively is.

- [X] Obsoletes `Spacing(float, bool)`
      (it doesn't ever actually need to be removed)
- [X] Adds `Spacing(Vector2, bool)` that works in the same way
- [X] New `Vector2.Scale()` and `Vector2?.Scale()` methods
- [X] New `Float?.Scale()` method as well

> Edit: Per conversation this PR now also includes:

- [X] Corrects scaling done in multiple methods to be consistent
- [X] Adds a few `...Scaled()` method masks to be consistent



---

> Edit: This question was answered, and the code changed in accordance with that answer.

@Taurenkey I see you implemented the `Scale()` method just below this, that accounts for both `Global Scale` and `Font Scale`.
Should `Spacing()` use `Scale()` on the `X` and `Y` instead of multiplying it by the `Global Scale`?
I kept it as it was to keep it consistent with the method it's replacing ... but I think it would be better to be correct than consistent on this, if that's what is correct.


https://github.com/NightmareXIV/ECommons/blob/f69e460e95134c72592654059843b138b4c01a9e/ECommons/ImGuiMethods/ImGuiEx/ImGuiEx.cs#L1244-L1248

<sup>if so, as a note, there are many many more places in ImGuiEx that need this change...</sup>