### PR TITLE
EzConfigGui support for `Window` and more `UiBuilder` support

### DIFF
--- a/ECommons/ECommonsMain.cs
+++ b/ECommons/ECommonsMain.cs
@@ -101,7 +101,10 @@ var type = "unknown build";
         GenericHelpers.Safe(DalamudReflector.Dispose);
         if(EzConfigGui.WindowSystem != null)
         {
-            Svc.PluginInterface.UiBuilder.OpenConfigUi -= EzConfigGui.Open;
+            if (EzConfigGui.Type is EzConfigGui.WindowType.Main or EzConfigGui.WindowType.Both)
+                Svc.PluginInterface.UiBuilder.OpenMainUi -= EzConfigGui.Open;
+            if (EzConfigGui.Type is EzConfigGui.WindowType.Config or EzConfigGui.WindowType.Both)
+                Svc.PluginInterface.UiBuilder.OpenConfigUi -= EzConfigGui.Open;
             Svc.PluginInterface.UiBuilder.Draw -= EzConfigGui.Draw;
             if(EzConfigGui.Config != null)
             {

--- a/ECommons/SimpleGui/ConfigWindow.cs
+++ b/ECommons/SimpleGui/ConfigWindow.cs
@@ -9,7 +9,7 @@ namespace ECommons.SimpleGui;
 
 public class ConfigWindow : Window
 {
-    public ConfigWindow(string name = null) : base($"{name ?? $"{DalamudReflector.GetPluginName()} v{ECommonsMain.Instance.GetType().Assembly.GetName().Version}"}###{DalamudReflector.GetPluginName()}")
+    public ConfigWindow(string? name = null) : base($"{name ?? $"{DalamudReflector.GetPluginName()} v{ECommonsMain.Instance.GetType().Assembly.GetName().Version}"}###{DalamudReflector.GetPluginName()}")
     {
         SizeConstraints = new()
         {

--- a/ECommons/SimpleGui/EzConfigGui.cs
+++ b/ECommons/SimpleGui/EzConfigGui.cs
@@ -22,7 +22,7 @@ public static class EzConfigGui
     /// Initialize the EzConfig WindowSystem
     /// </summary>
     /// <param name="draw">Draw method. If initialized this way, a new instance of <see cref="ConfigWindow"/> will be created. Any window parameters will need to be set in separate method instead of the constructor.</param>
-    /// <param name="config">Config to auto save</param>
+    /// <param name="config">Config to auto save on close</param>
     /// <param name="nameOverride">Override for the titlebar name. Default value is {InternalName v0.0.0.0}</param>
     /// <param name="windowType">Determines which UiBuilder event to subscribe to</param>
     public static void Init(Action draw, IPluginConfiguration config = null, string nameOverride = null, WindowType windowType = WindowType.Config)
@@ -35,7 +35,7 @@ public static class EzConfigGui
     /// Initialize the EzConfig WindowSystem
     /// </summary>
     /// <param name="window">Window instance. If window is not of type <see cref="ConfigWindow"/> then config autosaving will not function.</param>
-    /// <param name="config">Config to auto save</param>
+    /// <param name="config">Config to auto save on close</param>
     /// <param name="nameOverride">Override for the titlebar name. Default value is {InternalName v0.0.0.0}</param>
     /// <param name="windowType">Determines which UiBuilder event to subscribe to</param>
     public static T Init<T>(T window, IPluginConfiguration config = null, string nameOverride = null, WindowType windowType = WindowType.Config) where T : Window
@@ -55,6 +55,7 @@ public static class EzConfigGui
         Config = config;
         Window ??= new ConfigWindow(nameOverride);
         WindowSystem.AddWindow(Window);
+        Type = windowType;
         Svc.PluginInterface.UiBuilder.Draw += WindowSystem.Draw;
         switch(windowType)
         {

--- a/ECommons/SimpleGui/EzConfigGui.cs
+++ b/ECommons/SimpleGui/EzConfigGui.cs
@@ -11,27 +11,41 @@ namespace ECommons.SimpleGui;
 public static class EzConfigGui
 {
     public static WindowSystem WindowSystem { get; internal set; }
+    public static Window? Window { get; private set; }
+    public static WindowType Type { get; private set; }
     internal static Action Draw = null;
     internal static Action OnClose = null;
     internal static Action OnOpen = null;
     internal static IPluginConfiguration Config;
-    private static ConfigWindow configWindow;
-    public static Window Window { get { return configWindow; } }
 
-    public static void Init(Action draw, IPluginConfiguration config = null, string nameOverride = null)
+    /// <summary>
+    /// Initialize the EzConfig WindowSystem
+    /// </summary>
+    /// <param name="draw">Draw method. If initialized this way, a new instance of <see cref="ConfigWindow"/> will be created. Any window parameters will need to be set in separate method instead of the constructor.</param>
+    /// <param name="config">Config to auto save</param>
+    /// <param name="nameOverride">Override for the titlebar name. Default value is {InternalName v0.0.0.0}</param>
+    /// <param name="windowType">Determines which UiBuilder event to subscribe to</param>
+    public static void Init(Action draw, IPluginConfiguration config = null, string nameOverride = null, WindowType windowType = WindowType.Config)
     {
         Draw = draw;
-        Init(config, nameOverride);
+        Init(config, nameOverride, windowType);
     }
 
-    public static T Init<T>(T window, IPluginConfiguration config = null) where T : ConfigWindow
+    /// <summary>
+    /// Initialize the EzConfig WindowSystem
+    /// </summary>
+    /// <param name="window">Window instance. If window is not of type <see cref="ConfigWindow"/> then config autosaving will not function.</param>
+    /// <param name="config">Config to auto save</param>
+    /// <param name="nameOverride">Override for the titlebar name. Default value is {InternalName v0.0.0.0}</param>
+    /// <param name="windowType">Determines which UiBuilder event to subscribe to</param>
+    public static T Init<T>(T window, IPluginConfiguration config = null, string nameOverride = null, WindowType windowType = WindowType.Config) where T : Window
     {
-        configWindow = window;
-        Init(config);
+        Window = window;
+        Init(config, nameOverride, windowType);
         return window;
     }
 
-    private static void Init(IPluginConfiguration config, string nameOverride = null)
+    private static void Init(IPluginConfiguration config, string nameOverride = null, WindowType windowType = WindowType.Config)
     {
         if(WindowSystem != null)
         {
@@ -39,15 +53,28 @@ public static class EzConfigGui
         }
         WindowSystem = new($"ECommons@{DalamudReflector.GetPluginName()}");
         Config = config;
-        configWindow ??= new(nameOverride);
-        WindowSystem.AddWindow(configWindow);
+        Window ??= new ConfigWindow(nameOverride);
+        WindowSystem.AddWindow(Window);
         Svc.PluginInterface.UiBuilder.Draw += WindowSystem.Draw;
-        Svc.PluginInterface.UiBuilder.OpenConfigUi += Open;
+        switch(windowType)
+        {
+            case WindowType.Config:
+                Svc.PluginInterface.UiBuilder.OpenConfigUi += Open;
+                break;
+            case WindowType.Main:
+                Svc.PluginInterface.UiBuilder.OpenMainUi += Open;
+                break;
+            case WindowType.Both:
+                Svc.PluginInterface.UiBuilder.OpenConfigUi += Open;
+                Svc.PluginInterface.UiBuilder.OpenMainUi += Open;
+                break;
+        }
     }
 
     public static void Open()
     {
-        configWindow.IsOpen = true;
+        if(Window is not null)
+            Window.IsOpen = true;
     }
 
     public static void Open(string cmd = null, string args = null)
@@ -55,7 +82,7 @@ public static class EzConfigGui
         Open();
     }
 
-    public static void Toggle() => configWindow.Toggle();
+    public static void Toggle() => Window?.Toggle();
 
     /// <summary>
     /// Returns a window from the EzGui WindowSystem.
@@ -68,9 +95,14 @@ public static class EzConfigGui
     /// </summary>
     public static void RemoveWindow<T>() where T : Window
     {
-        if(!typeof(T).IsSubclassOf(typeof(Window))) return;
-        var window = WindowSystem.Windows.FirstOrDefault(w => w.GetType() == typeof(T));
-        if(window != null)
+        if(GetWindow<T>() is { } window)
             WindowSystem.RemoveWindow(window);
+    }
+
+    public enum WindowType
+    {
+        Config,
+        Main,
+        Both
     }
 }


### PR DESCRIPTION
feedback for the methods appreciated

1) `Init<T>` now takes in `Window` over `ConfigWindow`. This isn't a breaking change since CW already implements Window. It does mean though that you don't get the config saving provided by CW if you don't pass one but this is explained in the new xml docs

2) `Init` now also takes in the new `WindowType` to determine which `UiBuilder` event(s) to subscribe to. Most of my plugins only have a single window that is both the config and the main, and dalamud warns if you are missing subscribing to either of those events.