### PR TITLE
Add `TimeSpan` support to `EzThrottler`

### DIFF
--- a/ECommons/Throttlers/EzThrottler.cs
+++ b/ECommons/Throttlers/EzThrottler.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 
 namespace ECommons.Throttlers;
 
@@ -7,6 +8,8 @@ public static class EzThrottler
     internal static EzThrottler<string> Throttler = new();
 
     public static IReadOnlyCollection<string> ThrottleNames => Throttler.ThrottleNames;
+
+    public static bool Throttle(string name, TimeSpan ts, bool reThrottle = false) => Throttler.Throttle(name, ts.Milliseconds, reThrottle);
 
     public static bool Throttle(string name, int miliseconds = 500, bool rethrottle = false) => Throttler.Throttle(name, miliseconds, rethrottle);
 


### PR DESCRIPTION
This PR simply adds an overload of `Throttle` to accept `TimeSpan`s, since providing millisecond values for <X> Minutes is ... tedious.