### PR TITLE
Misc fixes

### DIFF
--- a/ECommons/Configuration/ExternalWriter.cs
+++ b/ECommons/Configuration/ExternalWriter.cs
@@ -143,8 +143,11 @@ public static class ExternalWriter
 
             for(var i = 0; i < iterations; i++)
             {
-                fs1.Read(one, 0, BYTES_TO_READ);
-                fs2.Read(two, 0, BYTES_TO_READ);
+                if(fs1.Read(one, 0, BYTES_TO_READ) != BYTES_TO_READ)
+                    return false;
+
+                if(fs2.Read(two, 0, BYTES_TO_READ) != BYTES_TO_READ)
+                    return false;
 
                 if(BitConverter.ToInt64(one, 0) != BitConverter.ToInt64(two, 0))
                     return false;

--- a/ECommons/GameHelpers/Player.cs
+++ b/ECommons/GameHelpers/Player.cs
@@ -73,7 +73,7 @@ public static unsafe class Player
     public static bool IsMoving => AgentMap.Instance()->IsPlayerMoving || IsJumping;
     public static bool IsJumping => Svc.Condition[ConditionFlag.Jumping] || Svc.Condition[ConditionFlag.Jumping61] || Character->IsJumping();
     public static bool Mounted => Svc.Condition[ConditionFlag.Mounted];
-    public static bool Mounting => Svc.Condition[ConditionFlag.Unknown57]; // condition 57 is set while mount up animation is playing
+    public static bool Mounting => Svc.Condition[ConditionFlag.MountOrOrnamentTransition];
     public static bool CanMount => Svc.Data.GetExcelSheet<TerritoryType>().GetRow(Territory).Mount && PlayerState.Instance()->NumOwnedMounts > 0;
     public static bool CanFly => Control.CanFly;
 
@@ -81,7 +81,7 @@ public static unsafe class Player
     public static bool IsAnimationLocked => AnimationLock > 0;
     public static bool IsDead => Svc.Condition[ConditionFlag.Unconscious];
     public static bool Revivable => IsDead && AgentRevive.Instance()->ReviveState != 0;
-    
+
     public static float DistanceTo(Vector3 other) => Vector3.Distance(Position, other);
     public static float DistanceTo(Vector2 other) => Vector2.Distance(Position.ToVector2(), other);
     public static float DistanceTo(IGameObject other) => Vector3.Distance(Position, other.Position);

--- a/ECommons/GenericHelpers/GenericHelpers.cs
+++ b/ECommons/GenericHelpers/GenericHelpers.cs
@@ -246,7 +246,7 @@ public static unsafe partial class GenericHelpers
                || Svc.Condition[ConditionFlag.InThatPosition]
                //|| Svc.Condition[ConditionFlag.TradeOpen]
                || Svc.Condition[ConditionFlag.Crafting]
-               || Svc.Condition[ConditionFlag.Crafting40]
+               || Svc.Condition[ConditionFlag.ExecutingCraftingAction]
                || Svc.Condition[ConditionFlag.PreparingToCraft]
                || Svc.Condition[ConditionFlag.InThatPosition]
                || Svc.Condition[ConditionFlag.Unconscious]

--- a/ECommons/UIHelpers/AddonMasterImplementations/WKSLottery.cs
+++ b/ECommons/UIHelpers/AddonMasterImplementations/WKSLottery.cs
@@ -4,11 +4,7 @@ using ECommons.Automation;
 using ECommons.DalamudServices;
 using ECommons.Logging;
 using FFXIVClientStructs.FFXIV.Component.GUI;
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace ECommons.UIHelpers.AddonMasterImplementations;
 
@@ -38,7 +34,7 @@ public partial class AddonMaster
                     SeString itemName = MemoryHelper.ReadSeStringNullTerminated((nint)Addon->AtkValues[91 + i * 7].String.Value).GetText();
                     string itemNameText = itemName.ToString();
 
-                    var ItemList = new WheelItems(this)
+                    var ItemList = new WheelItems()
                     {
                         itemId = itemId,
                         itemAmount = itemAmount,
@@ -65,7 +61,7 @@ public partial class AddonMaster
                     SeString itemName = MemoryHelper.ReadSeStringNullTerminated((nint)Addon->AtkValues[140 + i * 7].String.Value).GetText();
                     string itemNameText = itemName.ToString();
 
-                    var ItemList = new WheelItems(this)
+                    var ItemList = new WheelItems()
                     {
                         itemId = itemId,
                         itemAmount = itemAmount,
@@ -77,7 +73,7 @@ public partial class AddonMaster
             }
         }
 
-        public class WheelItems(WKSLottery master)
+        public class WheelItems
         {
             public uint itemId;
             public required string itemName;

--- a/ECommons/UIHelpers/AddonMasterImplementations/WKSMission.cs
+++ b/ECommons/UIHelpers/AddonMasterImplementations/WKSMission.cs
@@ -1,11 +1,7 @@
 ﻿using Dalamud.Memory;
 using ECommons.Automation;
-using ECommons.DalamudServices;
-using ECommons.Logging;
 using FFXIVClientStructs.FFXIV.Component.GUI;
-using Lumina.Excel.Sheets;
 using System.Collections.Generic;
-using System.Text.RegularExpressions;
 using ValueType = FFXIVClientStructs.FFXIV.Component.GUI.ValueType;
 
 namespace ECommons.UIHelpers.AddonMasterImplementations;
@@ -76,7 +72,7 @@ public partial class AddonMaster
 
         public class StellarMissions(WKSMission master, int index)
         {
-            public string Name;
+            public string Name { get; set; } = string.Empty;
             public uint MissionId;
 
             public void Select()

--- a/ECommons/UIHelpers/AddonMasterImplementations/WKSRecipeNotebook.cs
+++ b/ECommons/UIHelpers/AddonMasterImplementations/WKSRecipeNotebook.cs
@@ -51,7 +51,7 @@ public partial class AddonMaster
 
         public class CraftItems(WKSRecipeNotebook master, int index)
         {
-            public string Name;
+            public string Name { get; set; } = string.Empty;
 
             public void Select()
             {


### PR DESCRIPTION
- Added byte read checks in ExternalWriter to ensure that the number of bytes read by FileStream.Read matches the expected BYTES_TO_READ. If the number of bytes read is less than expected, the method will return false, ensuring the comparison logic only operates on complete data.
- Updated Mounting condition in Player to reflect updated name.
- Changed crafting condition in GenericHelpers to reflect updated name.
- Cleaned up using unused parameter in WheelItems class in WKSLottery.
- Initialized non-nullable field before contructor exits in StellarMissions and CraftItems.

Honestly just bored and tired of seeing RSRs build window filled with warnings