### PR TITLE
Add a default for `DALAMUD_HOME`

### DIFF
--- a/ECommons/ECommons.csproj
+++ b/ECommons/ECommons.csproj
@@ -38,6 +38,7 @@
     </PropertyGroup>
 
     <PropertyGroup Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Linux)))'">
+        <Dalamud_Home Condition="'$(DALAMUD_HOME)' == ''" >$(HOME)/.xlcore/dalamud/Hooks/dev/</Dalamud_Home>
         <DalamudLibPath>$(DALAMUD_HOME)/</DalamudLibPath>
         <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     </PropertyGroup>


### PR DESCRIPTION
It seems that -at least with Rider- it doesn't like any manner in which `DALAMUD_HOME` is defined, including from XLCore itself.
(possibly because via XLM it doesn't set it 'right'? I don't know)

Whatever the root reason, with this change I can build regardless of whether `DALAMUD_HOME` was set up correctly, and this is indeed the default value of `DALAMUD_HOME`.