### PR TITLE
Support new Dalamud ImGui Bindings

### DIFF
--- a/ECommons/Commands/CmdManager.cs
+++ b/ECommons/Commands/CmdManager.cs
@@ -1,5 +1,5 @@
 ﻿using ECommons.DalamudServices;
-using ImGuiNET;
+using Dalamud.Bindings.ImGui;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;

--- a/ECommons/ECommons.csproj
+++ b/ECommons/ECommons.csproj
@@ -82,12 +82,18 @@
             <HintPath>$(DalamudLibPath)Dalamud.Common.dll</HintPath>
             <Private>False</Private>
         </Reference>
-        <Reference Include="ImGui.NET">
-            <HintPath>$(DalamudLibPath)ImGui.NET.dll</HintPath>
+        <Reference Remove="ImGui.NET" />
+        <Reference Remove="ImGuiScene" />
+        <Reference Include="Dalamud.Bindings.ImGui">
+            <HintPath>$(DalamudLibPath)Dalamud.Bindings.ImGui.dll</HintPath>
             <Private>False</Private>
         </Reference>
-        <Reference Include="ImGuiScene">
-            <HintPath>$(DalamudLibPath)ImGuiScene.dll</HintPath>
+        <Reference Include="Dalamud.Bindings.ImPlot">
+            <HintPath>$(DalamudLibPath)Dalamud.Bindings.ImPlot.dll</HintPath>
+            <Private>False</Private>
+        </Reference>
+        <Reference Include="Dalamud.Bindings.ImGuizmo">
+            <HintPath>$(DalamudLibPath)Dalamud.Bindings.ImGuizmo.dll</HintPath>
             <Private>False</Private>
         </Reference>
         <Reference Include="Lumina">

--- a/ECommons/Funding/PatreonBanner.cs
+++ b/ECommons/Funding/PatreonBanner.cs
@@ -2,7 +2,7 @@
 using ECommons.DalamudServices;
 using ECommons.EzSharedDataManager;
 using ECommons.ImGuiMethods;
-using ImGuiNET;
+using Dalamud.Bindings.ImGui;
 using System;
 
 namespace ECommons.Funding;

--- a/ECommons/GenericHelpers/ConversionHelpers.cs
+++ b/ECommons/GenericHelpers/ConversionHelpers.cs
@@ -1,4 +1,4 @@
-﻿using ImGuiNET;
+﻿using Dalamud.Bindings.ImGui;
 using System;
 using System.Collections.Generic;
 using System.Globalization;

--- a/ECommons/GenericHelpers/GenericHelpers.Forms.cs
+++ b/ECommons/GenericHelpers/GenericHelpers.Forms.cs
@@ -1,7 +1,7 @@
 ﻿using ECommons.ImGuiMethods;
 using ECommons.Logging;
 using ECommons.WindowsFormsReflector;
-using ImGuiNET;
+using Dalamud.Bindings.ImGui;
 using System;
 using System.Collections.Generic;
 

--- a/ECommons/ImGuiMethods/ChangelogWindow.cs
+++ b/ECommons/ImGuiMethods/ChangelogWindow.cs
@@ -3,7 +3,7 @@ using Dalamud.Interface.Windowing;
 using Dalamud.Plugin;
 using ECommons.DalamudServices;
 using ECommons.Reflection;
-using ImGuiNET;
+using Dalamud.Bindings.ImGui;
 using System;
 
 namespace ECommons.ImGuiMethods;

--- a/ECommons/ImGuiMethods/EzColor.cs
+++ b/ECommons/ImGuiMethods/EzColor.cs
@@ -1,5 +1,5 @@
 ﻿using ECommons.DalamudServices;
-using ImGuiNET;
+using Dalamud.Bindings.ImGui;
 using Lumina.Excel.Sheets;
 using System;
 using System.Buffers.Binary;

--- a/ECommons/ImGuiMethods/EzFullscreenOverlayWindow.cs
+++ b/ECommons/ImGuiMethods/EzFullscreenOverlayWindow.cs
@@ -1,6 +1,6 @@
 ﻿using Dalamud.Interface.Utility;
 using Dalamud.Interface.Windowing;
-using ImGuiNET;
+using Dalamud.Bindings.ImGui;
 using System.Numerics;
 
 namespace ECommons.ImGuiMethods;

--- a/ECommons/ImGuiMethods/EzOverlayWindow.cs
+++ b/ECommons/ImGuiMethods/EzOverlayWindow.cs
@@ -1,7 +1,7 @@
 ﻿using Dalamud.Interface.Utility;
 using Dalamud.Interface.Windowing;
 using ECommons.Logging;
-using ImGuiNET;
+using Dalamud.Bindings.ImGui;
 using System.Numerics;
 
 namespace ECommons.ImGuiMethods;

--- a/ECommons/ImGuiMethods/FontAwesome.cs
+++ b/ECommons/ImGuiMethods/FontAwesome.cs
@@ -1,5 +1,5 @@
 ﻿using Dalamud.Interface;
-using ImGuiNET;
+using Dalamud.Bindings.ImGui;
 using System.Numerics;
 
 namespace ECommons.ImGuiMethods;

--- a/ECommons/ImGuiMethods/ImGuiBB.cs
+++ b/ECommons/ImGuiMethods/ImGuiBB.cs
@@ -1,4 +1,4 @@
-﻿using ImGuiNET;
+﻿using Dalamud.Bindings.ImGui;
 using System;
 using System.Collections.Generic;
 using System.Numerics;
@@ -74,7 +74,7 @@ public static class ImGuiBB
                         {
                             first = true;
                         }
-                        ImGui.Image(texture.ImGuiHandle, new(texture.Width, texture.Height));
+                        ImGui.Image(texture.Handle, new(texture.Width, texture.Height));
                     }
                 }
                 else

--- a/ECommons/ImGuiMethods/ImGuiDragDrop.cs
+++ b/ECommons/ImGuiMethods/ImGuiDragDrop.cs
@@ -1,4 +1,4 @@
-﻿using ImGuiNET;
+﻿using Dalamud.Bindings.ImGui;
 using System;
 using System.Runtime.CompilerServices;
 using System.Text;
@@ -16,7 +16,7 @@ public static class ImGuiDragDrop
     where T : unmanaged
     {
         var ptr = Unsafe.AsPointer(ref data);
-        ImGui.SetDragDropPayload(type, new IntPtr(ptr), (uint)Unsafe.SizeOf<T>(), cond);
+        ImGui.SetDragDropPayload(type, ptr, (uint)Unsafe.SizeOf<T>(), cond);
     }
 
     public static unsafe bool AcceptDragDropPayload<T>(string type, out T payload, ImGuiDragDropFlags flags = ImGuiDragDropFlags.None)
@@ -35,7 +35,7 @@ public static class ImGuiDragDrop
             var bytes = stackalloc byte[byteCount];
             Encoding.Default.GetBytes(chars, data.Length, bytes, byteCount);
 
-            ImGui.SetDragDropPayload(type, new IntPtr(bytes), (uint)byteCount, cond);
+            ImGui.SetDragDropPayload(type, bytes, (uint)byteCount, cond);
         }
     }
 

--- a/ECommons/ImGuiMethods/ImGuiEx/Alignment.cs
+++ b/ECommons/ImGuiMethods/ImGuiEx/Alignment.cs
@@ -1,4 +1,4 @@
-﻿using ImGuiNET;
+﻿using Dalamud.Bindings.ImGui;
 using System;
 using System.Collections.Generic;
 using System.Numerics;

--- a/ECommons/ImGuiMethods/ImGuiEx/Button.cs
+++ b/ECommons/ImGuiMethods/ImGuiEx/Button.cs
@@ -2,7 +2,7 @@
 using Dalamud.Interface.Components;
 using Dalamud.Interface.Utility;
 using ECommons.MathHelpers;
-using ImGuiNET;
+using Dalamud.Bindings.ImGui;
 using System;
 using System.Collections.Generic;
 using System.Numerics;

--- a/ECommons/ImGuiMethods/ImGuiEx/Checkbox.cs
+++ b/ECommons/ImGuiMethods/ImGuiEx/Checkbox.cs
@@ -1,4 +1,4 @@
-﻿using ImGuiNET;
+﻿using Dalamud.Bindings.ImGui;
 using System;
 
 namespace ECommons.ImGuiMethods;

--- a/ECommons/ImGuiMethods/ImGuiEx/CollectionCheckbox.cs
+++ b/ECommons/ImGuiMethods/ImGuiEx/CollectionCheckbox.cs
@@ -1,4 +1,4 @@
-﻿using ImGuiNET;
+﻿using Dalamud.Bindings.ImGui;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/ECommons/ImGuiMethods/ImGuiEx/DragDrop.cs
+++ b/ECommons/ImGuiMethods/ImGuiEx/DragDrop.cs
@@ -1,7 +1,7 @@
 ﻿using Dalamud.Interface;
 using Dalamud.Interface.Utility;
 using ECommons.Logging;
-using ImGuiNET;
+using Dalamud.Bindings.ImGui;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;

--- a/ECommons/ImGuiMethods/ImGuiEx/ExcelCombos.cs
+++ b/ECommons/ImGuiMethods/ImGuiEx/ExcelCombos.cs
@@ -1,6 +1,6 @@
 ﻿using Dalamud.Interface.Utility.Raii;
 using ECommons.DalamudServices;
-using ImGuiNET;
+using Dalamud.Bindings.ImGui;
 using Lumina.Excel;
 using System;
 using System.Collections.Generic;

--- a/ECommons/ImGuiMethods/ImGuiEx/EzTable.cs
+++ b/ECommons/ImGuiMethods/ImGuiEx/EzTable.cs
@@ -1,4 +1,4 @@
-﻿using ImGuiNET;
+﻿using Dalamud.Bindings.ImGui;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/ECommons/ImGuiMethods/ImGuiEx/ImGuiEx.cs
+++ b/ECommons/ImGuiMethods/ImGuiEx/ImGuiEx.cs
@@ -9,7 +9,7 @@ using ECommons.Logging;
 using ECommons.MathHelpers;
 using ECommons.Throttlers;
 using FFXIVClientStructs.FFXIV.Client.Game;
-using ImGuiNET;
+using Dalamud.Bindings.ImGui;
 using Lumina.Excel.Sheets;
 using System;
 using System.Collections.Generic;
@@ -570,7 +570,7 @@ public static unsafe partial class ImGuiEx
                 {
                     if(ThreadLoadImageHandler.TryGetIconTextureWrap((uint)cond.GetIcon(), false, out var texture))
                     {
-                        ImGui.Image(texture.ImGuiHandle, new Vector2(24f.Scale()));
+                        ImGui.Image(texture.Handle, new Vector2(24f.Scale()));
                         ImGui.SameLine();
                     }
                     if(CollectionCheckbox(name, cond, selectedJobs)) ret = true;
@@ -827,7 +827,7 @@ public static unsafe partial class ImGuiEx
     {
         if(ImGui.IsWindowCollapsed()) return false;
 
-        var currentID = ImGui.GetID(0);
+        var currentID = ImGui.GetID((byte*)0);
         if(currentID != headerLastWindowID || headerLastFrame != Svc.PluginInterface.UiBuilder.FrameCount)
         {
             headerLastWindowID = currentID;
@@ -889,8 +889,7 @@ public static unsafe partial class ImGuiEx
 
     public static bool IsKeyPressed(int key, bool repeat)
     {
-        var repeat2 = (byte)(repeat ? 1 : 0);
-        return ImGuiNative.igIsKeyPressed((ImGuiKey)key, repeat2) != 0;
+        return ImGui.IsKeyPressed((ImGuiKey)key, repeat);
     }
 
     public static float GetWindowContentRegionWidth()
@@ -1087,13 +1086,13 @@ public static unsafe partial class ImGuiEx
             ptr = null;
         }
 
-        byte* p_open2 = null;
-        var num2 = ImGuiNative.igBeginTabItem(ptr, p_open2, flags);
+        bool* p_open2 = null;
+        var num2 = ImGui.BeginTabItem(ptr, p_open2, flags);
         if(num > 2048)
         {
             Free(ptr);
         }
-        return num2 != 0;
+        return num2;
     }
 
     internal static unsafe byte* Allocate(int byteCount)

--- a/ECommons/ImGuiMethods/ImGuiEx/Inputs.cs
+++ b/ECommons/ImGuiMethods/ImGuiEx/Inputs.cs
@@ -1,10 +1,11 @@
 ﻿using Dalamud.Interface.Utility;
 using ECommons.Throttlers;
-using ImGuiNET;
+using Dalamud.Bindings.ImGui;
 using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+using System.Numerics;
 
 namespace ECommons.ImGuiMethods;
 public static partial class ImGuiEx
@@ -215,7 +216,7 @@ public static partial class ImGuiEx
 
     public static bool InputTextMultilineExpanding(string id, ref string text, uint maxLength = 500, int minLines = 2, int maxLines = 10, int? width = null)
     {
-        return ImGui.InputTextMultiline(id, ref text, maxLength, new(width ?? ImGui.GetContentRegionAvail().X, ImGui.CalcTextSize("A").Y * Math.Clamp(text.Split("\n").Length + 1, minLines, maxLines)));
+        return ImGui.InputTextMultiline(id, ref text, maxLength, new Vector2(width ?? ImGui.GetContentRegionAvail().X, ImGui.CalcTextSize("A").Y * Math.Clamp(text.Split("\n").Length + 1, minLines, maxLines)));
     }
 
     private static Dictionary<string, Box<string>> InputListValuesString = [];

--- a/ECommons/ImGuiMethods/ImGuiEx/Text.cs
+++ b/ECommons/ImGuiMethods/ImGuiEx/Text.cs
@@ -1,6 +1,6 @@
 ﻿using Dalamud.Interface;
 using Dalamud.Interface.Colors;
-using ImGuiNET;
+using Dalamud.Bindings.ImGui;
 using System.Numerics;
 
 namespace ECommons.ImGuiMethods;

--- a/ECommons/ImGuiMethods/ImGuiNoRef.cs
+++ b/ECommons/ImGuiMethods/ImGuiNoRef.cs
@@ -1,4 +1,4 @@
-﻿using ImGuiNET;
+﻿using Dalamud.Bindings.ImGui;
 
 namespace ECommons.ImGuiMethods;
 

--- a/ECommons/ImGuiMethods/ImGuiTrans.cs
+++ b/ECommons/ImGuiMethods/ImGuiTrans.cs
@@ -1,4 +1,4 @@
-﻿using ImGuiNET;
+﻿using Dalamud.Bindings.ImGui;
 using System;
 using System.Numerics;
 
@@ -16,7 +16,7 @@ public class ImGuiTrans
     {
         foreach(var c in Enum.GetValues<ImGuiCol>())
         {
-            if(c == ImGuiCol.COUNT) continue;
+            if(c == ImGuiCol.Count) continue;
             var col = ImGui.GetStyle().Colors[(int)c];
             ImGui.PushStyleColor(c, col with { W = col.W * v });
         }

--- a/ECommons/ImGuiMethods/MiddleOverlayWindow.cs
+++ b/ECommons/ImGuiMethods/MiddleOverlayWindow.cs
@@ -1,7 +1,7 @@
 ﻿using Dalamud.Interface.Utility;
 using Dalamud.Interface.Windowing;
 using ECommons.DalamudServices;
-using ImGuiNET;
+using Dalamud.Bindings.ImGui;
 using System;
 using System.Numerics;
 

--- a/ECommons/ImGuiMethods/NotifyWindow.cs
+++ b/ECommons/ImGuiMethods/NotifyWindow.cs
@@ -1,6 +1,6 @@
 ﻿using Dalamud.Interface.Utility;
 using Dalamud.Interface.Windowing;
-using ImGuiNET;
+using Dalamud.Bindings.ImGui;
 using System;
 
 namespace ECommons.ImGuiMethods;

--- a/ECommons/ImGuiMethods/TerritorySelection/TerritorySelector.cs
+++ b/ECommons/ImGuiMethods/TerritorySelection/TerritorySelector.cs
@@ -4,7 +4,7 @@ using ECommons.DalamudServices;
 using ECommons.ExcelServices;
 using ECommons.GameHelpers;
 using ECommons.Schedulers;
-using ImGuiNET;
+using Dalamud.Bindings.ImGui;
 using Lumina.Excel.Sheets;
 using System;
 using System.Collections.Generic;

--- a/ECommons/Loader/PluginLoader.cs
+++ b/ECommons/Loader/PluginLoader.cs
@@ -4,7 +4,7 @@ using Dalamud.Plugin;
 using ECommons.ImGuiMethods;
 using ECommons.Logging;
 using ECommons.Reflection;
-using ImGuiNET;
+using Dalamud.Bindings.ImGui;
 using System;
 using System.IO;
 using System.Linq;

--- a/ECommons/Logging/InternalLog.cs
+++ b/ECommons/Logging/InternalLog.cs
@@ -2,7 +2,7 @@ using Dalamud.Interface.Colors;
 using ECommons.CircularBuffers;
 using ECommons.ImGuiMethods;
 using ECommons.Reflection;
-using ImGuiNET;
+using Dalamud.Bindings.ImGui;
 using Serilog.Events;
 using System;
 using System.Linq;

--- a/ECommons/Networking/ProxySettings.cs
+++ b/ECommons/Networking/ProxySettings.cs
@@ -1,5 +1,5 @@
 ﻿using ECommons.ImGuiMethods;
-using ImGuiNET;
+using Dalamud.Bindings.ImGui;
 using Newtonsoft.Json;
 using System;
 using System.Collections.Immutable;

--- a/ECommons/Reflection/DalamudReflector.cs
+++ b/ECommons/Reflection/DalamudReflector.cs
@@ -5,7 +5,7 @@ using ECommons.DalamudServices;
 using ECommons.EzSharedDataManager;
 using ECommons.Logging;
 using ECommons.Schedulers;
-using ImGuiNET;
+using Dalamud.Bindings.ImGui;
 using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;

--- a/ECommons/SimpleGui/PopupWindow.cs
+++ b/ECommons/SimpleGui/PopupWindow.cs
@@ -1,6 +1,6 @@
 ﻿using Dalamud.Interface.Windowing;
 using ECommons.DalamudServices;
-using ImGuiNET;
+using Dalamud.Bindings.ImGui;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;


### PR DESCRIPTION
- [X] Switches all references to `ImGuiNET` with `Dalamud.Bindings.ImGui`
- [X] Switches all `IDalamudTextureWrap` `ImGuiHandle` references to just `Handle`
- [X] Switches all `null` IDs to `null` pointers
- [X] Switches Project to include references to the new bindings, and remove the old

> [!NOTE]
> Drafted until this can actually be tested against the beta/release branch, but does work on the `imgui-bindings` branch.