### PR TITLE
[API13] Fixes

### DIFF
--- a/ECommons/ExcelServices/ExcelActionHelper.cs
+++ b/ECommons/ExcelServices/ExcelActionHelper.cs
@@ -11,11 +11,11 @@ public static unsafe class ExcelActionHelper
     {
         var detail = ActionManager.Instance()->GetRecastGroupDetail(Svc.Data.GetExcelSheet<Lumina.Excel.Sheets.Action>().GetRow(id).CooldownGroup - 1);
         var cdg2 = Svc.Data.GetExcelSheet<Lumina.Excel.Sheets.Action>().GetRow(id).AdditionalCooldownGroup - 1;
-        var ret = detail->IsActive == 1 ? detail->Total - detail->Elapsed : 0;
+        var ret = detail->IsActive ? detail->Total - detail->Elapsed : 0;
         if(cdg2 > 0)
         {
             var detail2 = ActionManager.Instance()->GetRecastGroupDetail(cdg2);
-            var cd2 = detail2->IsActive == 1 ? detail2->Total - detail2->Elapsed : 0;
+            var cd2 = detail2->IsActive ? detail2->Total - detail2->Elapsed : 0;
             return Math.Max(cd2, ret);
         }
         return ret;

--- a/ECommons/GameHelpers/Player.cs
+++ b/ECommons/GameHelpers/Player.cs
@@ -40,7 +40,7 @@ public static unsafe class Player
     public static string GetNameWithWorld(this IPlayerCharacter pc) => pc == null ? null : (pc.Name.ToString() + "@" + pc.HomeWorld.ValueNullable?.Name.ToString());
 
     public static int Level => Svc.ClientState.LocalPlayer?.Level ?? 0;
-    public static bool IsLevelSynced => PlayerState.Instance()->IsLevelSynced == 1;
+    public static bool IsLevelSynced => PlayerState.Instance()->IsLevelSynced;
     public static int SyncedLevel => PlayerState.Instance()->SyncedLevel;
     public static int UnsyncedLevel => GetUnsyncedLevel(GetJob(Object));
     public static int GetUnsyncedLevel(Job job) => PlayerState.Instance()->ClassJobLevels[Svc.Data.GetExcelSheet<ClassJob>().GetRowOrDefault((uint)job).Value.ExpArrayIndex];
@@ -60,7 +60,7 @@ public static unsafe class Player
     public static TerritoryIntendedUseEnum TerritoryIntendedUse => (TerritoryIntendedUseEnum)(Svc.Data.GetExcelSheet<TerritoryType>().GetRowOrDefault(Territory)?.TerritoryIntendedUse.ValueNullable?.RowId ?? default);
     public static uint HomeAetheryteTerritory => Svc.Data.GetExcelSheet<Aetheryte>().GetRowOrDefault(PlayerState.Instance()->HomeAetheryteId).Value.Territory.RowId;
     public static bool IsInDuty => GameMain.Instance()->CurrentContentFinderConditionId != 0;
-    public static bool IsOnIsland => MJIManager.Instance()->IsPlayerInSanctuary == 1;
+    public static bool IsOnIsland => MJIManager.Instance()->IsPlayerInSanctuary;
     public static bool IsInPvP => GameMain.IsInPvPInstance();
 
     public static Job Job => GetJob(Svc.ClientState.LocalPlayer);

--- a/ECommons/PartyFunctions/UniversalParty.cs
+++ b/ECommons/PartyFunctions/UniversalParty.cs
@@ -14,7 +14,7 @@ namespace ECommons.PartyFunctions;
 public static unsafe class UniversalParty
 {
     public static bool IsCrossWorldParty => Svc.Condition[ConditionFlag.ParticipatingInCrossWorldPartyOrAlliance];
-    public static bool IsAlliance => IsCrossWorldParty && InfoProxyCrossRealm.Instance()->IsInAllianceRaid != 0;
+    public static bool IsAlliance => IsCrossWorldParty && InfoProxyCrossRealm.Instance()->IsInAllianceRaid;
 
     public static int Length => Members.Count;
     public static int LengthPlayback => MembersPlayback.Count;


### PR DESCRIPTION
- [X] Uses new bools instead of truthy ints

@Limiana There is one last fix required for API13, and it's https://github.com/NightmareXIV/ECommons/blob/9e2c4476d7fe27d50582d561b0cc4927070f2be2/ECommons/UIHelpers/AddonMasterImplementations/_CharaSelectWorldServer.cs#L34
That doesn't `(nint)` anymore. It looks like `str` has an extension to just go straight to a real string now, but I'm not convinced I have any real idea.