### PR TITLE
Fixed scoring for other languages.

### DIFF
--- a/ECommons/UIHelpers/AddonMasterImplementations/WKSMissionInfomation.cs
+++ b/ECommons/UIHelpers/AddonMasterImplementations/WKSMissionInfomation.cs
@@ -1,5 +1,6 @@
 ﻿using Dalamud.Memory;
 using FFXIVClientStructs.FFXIV.Component.GUI;
+using System.Globalization;
 
 namespace ECommons.UIHelpers.AddonMasterImplementations;
 public partial class AddonMaster
@@ -28,9 +29,16 @@ public partial class AddonMaster
             get
             {
                 var rawValue = MemoryHelper.ReadSeStringNullTerminated((nint)Addon->AtkValues[2].String.Value).GetText();
-                rawValue = rawValue.Replace(",", ""); // remove thousand separators
-                if(uint.TryParse(rawValue, out var result))
+
+                // Number coversion test #1.
+                if(uint.TryParse(rawValue, NumberStyles.AllowThousands, CultureInfo.InvariantCulture, out var result))
                     return result;
+
+                // Fallback: if the first test fails
+                var cleanedValue = System.Text.RegularExpressions.Regex.Replace(rawValue, @"[^\d]", "");
+                if(uint.TryParse(cleanedValue, out result))
+                    return result;
+
                 return 0; // fallback if parsing fails
             }
         }
@@ -40,9 +48,16 @@ public partial class AddonMaster
             get
             {
                 var rawValue = MemoryHelper.ReadSeStringNullTerminated((nint)Addon->AtkValues[3].String.Value).GetText();
-                rawValue = rawValue.Replace(",", ""); // remove thousand separators
-                if(uint.TryParse(rawValue, out var result))
+
+                // Number coversion test #1.
+                if(uint.TryParse(rawValue, NumberStyles.AllowThousands, CultureInfo.InvariantCulture, out var result))
                     return result;
+
+                // Fallback: if the first test fails
+                var cleanedValue = System.Text.RegularExpressions.Regex.Replace(rawValue, @"[^\d]", "");
+                if(uint.TryParse(cleanedValue, out result))
+                    return result;
+
                 return 0; // fallback if parsing fails
             }
         }
@@ -52,9 +67,38 @@ public partial class AddonMaster
             get
             {
                 var rawValue = MemoryHelper.ReadSeStringNullTerminated((nint)Addon->AtkValues[4].String.Value).GetText();
-                rawValue = rawValue.Replace(",", ""); // remove thousand separators
-                if(uint.TryParse(rawValue, out var result))
+
+                // Number coversion test #1.
+                if(uint.TryParse(rawValue, NumberStyles.AllowThousands, CultureInfo.InvariantCulture, out var result))
                     return result;
+
+                // Fallback: if the first test fails
+                var cleanedValue = System.Text.RegularExpressions.Regex.Replace(rawValue, @"[^\d]", "");
+                if(uint.TryParse(cleanedValue, out result))
+                    return result;
+
+                return 0; // fallback if parsing fails
+            }
+        }
+
+        public uint CriticalScore
+        {
+            get
+            {
+                var rawValue = MemoryHelper.ReadSeStringNullTerminated((nint)Addon->AtkValues[5].String.Value).GetText();
+
+                // Extract the left side of the slash
+                var leftSide = rawValue.Split('/')[0].Trim();
+
+                // Number conversion test #1.
+                if(uint.TryParse(leftSide, NumberStyles.AllowThousands, CultureInfo.InvariantCulture, out var result))
+                    return result;
+
+                // Fallback: if the first test fails
+                var cleanedValue = System.Text.RegularExpressions.Regex.Replace(leftSide, @"[^\d]", "");
+                if(uint.TryParse(cleanedValue, out result))
+                    return result;
+
                 return 0; // fallback if parsing fails
             }
         }


### PR DESCRIPTION
French, German, and probably jp all use a different numbering system. And since it's stored as a string *-sighs-*

Went through and added a check to all of these to return a proper value on other languages.

Also added a check for critical missions specifically (they return a 0/1 vs an actual score)