### PR TITLE
Added Collectable Shop + Base Shop Info

### DIFF
--- a/ECommons/UIHelpers/AddonMasterImplementations/InclusionShop.cs
+++ b/ECommons/UIHelpers/AddonMasterImplementations/InclusionShop.cs
@@ -1,0 +1,60 @@
+﻿using FFXIVClientStructs.FFXIV.Client.Game.UI;
+using FFXIVClientStructs.FFXIV.Component.GUI;
+using System.Collections.Generic;
+using Callback = ECommons.Automation.Callback;
+using ValueType = FFXIVClientStructs.FFXIV.Component.GUI.ValueType;
+
+namespace ECommons.UIHelpers.AddonMasterImplementations;
+
+public partial class AddonMaster
+{
+    public unsafe class InclusionShop : AddonMasterBase<AtkUnitBase>
+    {
+        public InclusionShop(nint addon) : base(addon) { }
+        public InclusionShop(void* addon) : base(addon) { }
+        public uint CurrencyAmount => Addon->AtkValues[297].UInt;
+        public uint NumEntries => Addon->AtkValues[298].UInt;
+
+        public class ShopItemInfo(InclusionShop master, int index)
+        {
+            public uint ItemId;
+            public uint CurrencyId;
+            public uint Cost;
+            public void Select(int amount = 1)
+            {
+                Callback.Fire(master.Base, true, 14, index, amount);
+            }
+        }
+
+        public ShopItemInfo[] ShopItems
+        {
+            get
+            {
+                var ret = new List<ShopItemInfo>();
+                for(int i = 0; i < NumEntries; i++)
+                {
+                    var itemId = Addon->AtkValues[300 + (i * 18)].UInt;
+
+                    if (itemId == 0)
+                        continue;
+                    else
+                    {
+                        var costItemId = Addon->AtkValues[305 + (i * 18)].UInt;
+                        var costAmount = Addon->AtkValues[311 + (i * 18)].UInt;
+
+                        var itemEntry = new ShopItemInfo(this, i)
+                        {
+                            ItemId = itemId,
+                            CurrencyId = costItemId,
+                            Cost = costAmount,
+                        };
+                        ret.Add(itemEntry);
+                    }
+                }
+                return [.. ret];
+            }
+        }
+
+        public override string AddonDescription { get; } = "Crafter/Gathering Script Shop Window";
+    }
+}

--- a/ECommons/UIHelpers/AddonMasterImplementations/ShopExchangeCurrency.cs
+++ b/ECommons/UIHelpers/AddonMasterImplementations/ShopExchangeCurrency.cs
@@ -1,0 +1,90 @@
+﻿using Dalamud.Bindings.ImGui;
+using ECommons.DalamudServices;
+using FFXIVClientStructs.FFXIV.Client.Game.UI;
+using FFXIVClientStructs.FFXIV.Component.GUI;
+using Lumina.Excel.Sheets;
+using System.Collections.Generic;
+using System.Linq;
+using Callback = ECommons.Automation.Callback;
+using ValueType = FFXIVClientStructs.FFXIV.Component.GUI.ValueType;
+
+namespace ECommons.UIHelpers.AddonMasterImplementations;
+
+public partial class AddonMaster
+{
+    public unsafe class ShopExchangeCurrency : AddonMasterBase<AtkUnitBase>
+    {
+        public ShopExchangeCurrency(nint addon) : base(addon) { }
+        public ShopExchangeCurrency(void* addon) : base(addon) { }
+
+        public uint CurrencyAmount => Addon->AtkValues[84].UInt;
+        public uint NumEntries => Addon->AtkValues[4].UInt;
+        public uint CurrencyId
+        {
+            get
+            {
+                var iconId = Addon->AtkValues[85].UInt;
+                var row = Svc.Data.GetExcelSheet<Item>().Where(x => x.Icon == iconId).FirstOrDefault().RowId;
+                if (row != 0)
+                {
+                    return row;
+                }
+                else
+                {
+                    return 0;
+                }
+            }
+        }
+        // 1064 - Start of ItemIds
+        // 454 - Start of Shop Price
+
+        public class ShopItemInfo(ShopExchangeCurrency master, int index)
+        {
+            public uint ItemId;
+            public uint CostAmount;
+            public void Select(int amount = 1)
+            {
+                Callback.Fire(master.Base, true, 0, index, amount);
+            }
+        }
+
+        public class CostInfo
+        {
+            public uint itemId;
+            public uint cost;
+        }
+
+        /// <summary>
+        /// This exist as it is because "ShopExchangeCurrency" covers...  alot of different shop types that exist. <br></br>
+        /// This just covers the basic "Item -> Gil/Currency Exchange", since ones where you need to exchange items are coded differently
+        /// </summary>
+        public ShopItemInfo[] BasicShopItems
+        {
+            get
+            {
+                var ret = new List<ShopItemInfo>();
+                for (int i = 0; i < NumEntries; i++)
+                {
+                    var itemId = Addon->AtkValues[1064 + (i * 1)].UInt;
+
+                    if(itemId == 0)
+                        continue;
+                    else
+                    {
+                        var costAmount = Addon->AtkValues[454 + (i * 1)].UInt;
+                        var newEntry = new ShopItemInfo(this, i)
+                        {
+                            ItemId = itemId,
+                            CostAmount = costAmount
+                        };
+                        ret.Add(newEntry);
+                    }
+                }
+                return [.. ret];
+            }
+        }
+
+
+        public override string AddonDescription { get; } = "Item Exchange Window";
+    }
+}


### PR DESCRIPTION
Added info to grab from the collectable shop (InclusionShop) and the basic shops (ShopExchangeCurrency).

There's... some minor wonkyness that comes with the basic shop. The base addon info is different than the collectables (aka all the data is scattered around in the ATK values) and there isn't a good way to get the currencyId of what is required. I'll go through and add the itemExchange versions of it later because those also read differently than the basic gil/moon currency shops.