### PR TITLE
Normalize repo URL comparison in HasRepo/AddRepo

### DIFF
--- a/ECommons/Reflection/DalamudReflector.cs
+++ b/ECommons/Reflection/DalamudReflector.cs
@@ -380,7 +380,7 @@ public static class DalamudReflector
         var repolist = (System.Collections.IEnumerable)conf.GetFoP("ThirdRepoList");
         if(repolist != null)
             foreach(var r in repolist)
-                if((string)r.GetFoP("Url") == repoURL)
+                if(IsSameRepoUrl((string)r.GetFoP("Url"), repoURL))
                     return true;
         return false;
     }
@@ -396,13 +396,16 @@ public static class DalamudReflector
         var repolist = (System.Collections.IEnumerable)conf.GetFoP("ThirdRepoList");
         if(repolist != null)
             foreach(var r in repolist)
-                if((string)r.GetFoP("Url") == repoURL)
+                if(IsSameRepoUrl((string)r.GetFoP("Url"), repoURL))
                     return;
         var instance = Activator.CreateInstance(Svc.PluginInterface.GetType().Assembly.GetType("Dalamud.Configuration.ThirdPartyRepoSettings")!);
         instance.SetFoP("Url", repoURL);
         instance.SetFoP("IsEnabled", enabled);
         conf.GetFoP<System.Collections.IList>("ThirdRepoList").Add(instance!);
     }
+
+    private static bool IsSameRepoUrl(string? a, string? b)
+        => string.Equals(a?.Trim().TrimEnd('/'), b?.Trim().TrimEnd('/'), StringComparison.OrdinalIgnoreCase);
 
     /// <summary>
     /// Installs a plugin from a remote Plugin Master.


### PR DESCRIPTION
Same bug I shipped in my own migration code recently after kawaii's suggestion, though mine was way worse. So let's just all blame kawaii! jk

Both compare Url with ==, so a repo already in the list under a slightly different URL (trailing slash, different case) doesn't match, and AddRepo adds a duplicate

Added an IsSameRepoUrl helper (trim, trailing slash, OrdinalIgnoreCase) for both checks. Stored value unchanged, since Dalamud matches InstalledFromUrl exactly. Mostly hits people who added the repo by hand, so low priority