### PR TITLE
add GameIcons

### DIFF
--- a/ECommons/ECommons.csproj
+++ b/ECommons/ECommons.csproj
@@ -63,6 +63,7 @@
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       </PackageReference>
+      <PackageReference Include="SixLabors.ImageSharp" Version="3.1.12" />
     </ItemGroup>
 
     <ItemGroup>

--- a/ECommons/ECommonsMain.cs
+++ b/ECommons/ECommonsMain.cs
@@ -170,6 +170,7 @@ var type = "unknown build";
         }
         GenericHelpers.Safe(EzConfig.Dispose);
         GenericHelpers.Safe(ThreadLoadImageHandler.ClearAll);
+        GenericHelpers.Safe(GameIcons.ClearAll);
         GenericHelpers.Safe(ObjectLife.Dispose);
         GenericHelpers.Safe(DalamudReflector.Dispose);
         if(EzConfigGui.WindowSystem != null)

--- a/ECommons/ImGuiMethods/GameIcons.cs
+++ b/ECommons/ImGuiMethods/GameIcons.cs
@@ -1,0 +1,139 @@
+using Dalamud.Bindings.ImGui;
+using Dalamud.Game;
+using Dalamud.Interface;
+using Dalamud.Interface.Textures;
+using Dalamud.Interface.Textures.TextureWraps;
+using ECommons.DalamudServices;
+using ECommons.Logging;
+using Lumina.Data.Files;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.PixelFormats;
+using SixLabors.ImageSharp.Processing;
+using SixLabors.ImageSharp.Processing.Processors.Transforms;
+using System;
+using System.Collections.Concurrent;
+using System.IO;
+using System.Numerics;
+
+namespace ECommons.ImGuiMethods;
+
+public static class GameIcons
+{
+    private static readonly ConcurrentDictionary<CacheKey, IDalamudTextureWrap?> Cache = [];
+
+    public static IResampler Resampler { get; set; } = KnownResamplers.Lanczos3;
+    public static int MaximumSize { get; set; } = 512;
+
+    public static bool DrawInline(uint iconId, bool sameLine = true) => DrawInline(new GameIconLookup(iconId), sameLine);
+
+    public static bool DrawInline(GameIconLookup lookup, bool sameLine = true)
+    {
+        var size = MathF.Round(ImGui.GetTextLineHeightWithSpacing());
+        if(!Draw(lookup, new Vector2(size))) return false;
+        if(sameLine) ImGui.SameLine();
+        return true;
+    }
+
+    public static void DrawInlineOrIcon(uint? iconId, FontAwesomeIcon fallback, Vector4? fallbackColor = null)
+    {
+        if(iconId is { } id && DrawInline(id)) return;
+        ImGuiEx.Icon(fallbackColor ?? ImGui.GetStyle().Colors[(int)ImGuiCol.Text], fallback);
+    }
+
+    public static bool Draw(uint iconId, float size) => Draw(new GameIconLookup(iconId), new Vector2(size));
+    public static bool Draw(uint iconId, Vector2 size) => Draw(new GameIconLookup(iconId), size);
+
+    public static bool Draw(GameIconLookup lookup, Vector2 size)
+    {
+        var width = (int)MathF.Round(size.X);
+        var height = (int)MathF.Round(size.Y);
+        if(Get(lookup, width, height) is not { } texture) return false;
+        var position = ImGui.GetCursorScreenPos();
+        ImGui.SetCursorScreenPos(new Vector2(MathF.Round(position.X), MathF.Round(position.Y)));
+        ImGui.Image(texture.Handle, new Vector2(width, height));
+        return true;
+    }
+
+    public static bool TryGetScaledIcon(uint iconId, int size, out IDalamudTextureWrap texture) => TryGetScaledIcon(new GameIconLookup(iconId), size, size, out texture);
+
+    public static bool TryGetScaledIcon(GameIconLookup lookup, int width, int height, out IDalamudTextureWrap texture)
+    {
+        texture = Get(lookup, width, height);
+        return texture != null;
+    }
+
+    public static void Invalidate(uint iconId)
+    {
+        foreach(var x in Cache)
+        {
+            if(x.Key.IconId != iconId) continue;
+            if(Cache.TryRemove(x.Key, out var texture)) GenericHelpers.Safe(() => texture?.Dispose());
+        }
+    }
+
+    public static void ClearAll()
+    {
+        foreach(var x in Cache)
+        {
+            GenericHelpers.Safe(() => x.Value?.Dispose());
+        }
+        GenericHelpers.Safe(Cache.Clear);
+    }
+
+    private static IDalamudTextureWrap? Get(GameIconLookup lookup, int width, int height)
+    {
+        if(width <= 0 || height <= 0 || width > MaximumSize || height > MaximumSize) return null;
+        var key = new CacheKey(lookup.IconId, lookup.ItemHq, lookup.HiRes, lookup.Language, width, height);
+        if(Cache.TryGetValue(key, out var cached)) return cached;
+
+        IDalamudTextureWrap? texture = null;
+        try
+        {
+            if(TryGetTexFile(lookup, out var file) && file.Header.Width > 0 && file.Header.Height > 0)
+                texture = Resample(file, lookup.IconId, width, height);
+            else
+                PluginLog.Warning($"[GameIcons] Could not find icon {lookup.IconId}");
+        }
+        catch(Exception e)
+        {
+            PluginLog.Warning($"[GameIcons] Could not resample icon {lookup.IconId} to {width}x{height}:\n{e}");
+        }
+
+        Cache[key] = texture;
+        return texture;
+    }
+
+    private static IDalamudTextureWrap Resample(TexFile file, uint iconId, int width, int height)
+    {
+        //these are bgra, not rgba
+        using var image = Image.LoadPixelData<Bgra32>(file.ImageData, file.Header.Width, file.Header.Height);
+        image.Mutate(x => x.Resize(width, height, Resampler));
+
+        var bitmap = new byte[width * height * 4];
+        image.CopyPixelDataTo(bitmap);
+
+        return Svc.Texture.CreateFromRaw(RawImageSpecification.Bgra32(width, height), bitmap, $"ECommons.GameIcons {iconId}@{width}x{height}");
+    }
+
+    private static bool TryGetTexFile(GameIconLookup lookup, out TexFile file)
+    {
+        file = null;
+        if(!Svc.Texture.TryGetIconPath(lookup, out var path)) return false;
+
+        var substituted = Svc.TextureSubstitution.GetSubstitutedPath(path);
+        if(substituted != path && Path.IsPathRooted(substituted))
+        {
+            if(substituted.EndsWith(".tex", StringComparison.OrdinalIgnoreCase) && File.Exists(substituted))
+                file = Svc.Data.GameData.GetFileFromDisk<TexFile>(substituted, path);
+        }
+        else
+        {
+            file = Svc.Data.GetFile<TexFile>(substituted);
+        }
+
+        file ??= Svc.Data.GetFile<TexFile>(path);
+        return file != null;
+    }
+
+    private readonly record struct CacheKey(uint IconId, bool ItemHq, bool HiRes, ClientLanguage? Language, int Width, int Height);
+}

--- a/ECommons/packages.lock.json
+++ b/ECommons/packages.lock.json
@@ -7,6 +7,12 @@
         "requested": "[3.12.0-beta1.25218.8, )",
         "resolved": "3.12.0-beta1.25218.8",
         "contentHash": "Hl/CiTNuFm43+DdMDpmm9lSFnlwISwtgGKmByWdwZoGgtJfefKP6fPwnmOVsW/s42ahOEhPpIYFlZJ2+AqeJEQ=="
+      },
+      "SixLabors.ImageSharp": {
+        "type": "Direct",
+        "requested": "[3.1.12, )",
+        "resolved": "3.1.12",
+        "contentHash": "iAg6zifihXEFS/t7fiHhZBGAdCp3FavsF4i2ZIDp0JfeYeDVzvmlbY1CNhhIKimaIzrzSi5M/NBFcWvZT2rB/A=="
       }
     }
   }


### PR DESCRIPTION
resamples game icons on the cpu to the size they're drawn at instead of letting the gpu blur them

adds SixLabors.ImageSharp.

you can see this live in questoinable